### PR TITLE
sigmoid optimization

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -21,4 +21,4 @@ macro _not_implemented()
   end
 end
 
-sigmoid(x) = 1 / (1 + exp(-x))
+sigmoid(x) = one(x) / (one(x) + exp(-x))


### PR DESCRIPTION
Just noticed something that is mentioned in the julia performance tips section about using consistent types could be applied to this line.

```
julia> sigmoid(x) = 1/(1+exp(-x))
sigmoid (generic function with 1 method)

julia> sigmoid_alt(x) = one(x) / (one(x) + exp(-x))
sigmoid_alt (generic function with 1 method)
```
Then I ran them each with ints and floats to make the REPL compile them before running the following:
```
julia> @time for i=1.0:0.1:100000.0
       sigmoid(i)
       end
  0.004296 seconds

julia> @time for i=1.0:0.1:100000.0
       sigmoid_alt(i)
       end
  0.003985 seconds
```