### PR TITLE
Dependency changes

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,4 +3,5 @@ julia 0.4
 StatsBase
 MLBase
 Reexport
+Requires
 RecipesBase

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.4
-Requires
+
 StatsBase
 MLBase
-ArrayViews
 Reexport
+RecipesBase

--- a/src/LearnBase.jl
+++ b/src/LearnBase.jl
@@ -5,9 +5,7 @@ module LearnBase
 
 using Reexport
 @reexport using MLBase
-# using Requires
-# using ArrayViews
-# using UnicodePlots
+using Requires
 using RecipesBase
 
 import Base: show, shuffle!, convert, call, print, transpose, minimum, copy

--- a/src/LearnBase.jl
+++ b/src/LearnBase.jl
@@ -5,14 +5,15 @@ module LearnBase
 
 using Reexport
 @reexport using MLBase
-using Requires
-using ArrayViews
+# using Requires
+# using ArrayViews
 # using UnicodePlots
+using RecipesBase
 
 import Base: show, shuffle!, convert, call, print, transpose, minimum, copy
-@require UnicodePlots begin
-    import UnicodePlots: lineplot, lineplot!
-end
+# @require UnicodePlots begin
+#     import UnicodePlots: lineplot, lineplot!
+# end
 import StatsBase: fit, fit!, predict, predict!, nobs, coef,
                   deviance, loglikelihood, coeftable, stderr,
                   vcov, confint, residuals, model_response

--- a/src/loss/io.jl
+++ b/src/loss/io.jl
@@ -7,130 +7,159 @@ print(io::IO, loss::L1EpsilonInsLoss, args...) = print(io, typeof(loss).name.nam
 print(io::IO, loss::L2EpsilonInsLoss, args...) = print(io, typeof(loss).name.name, " with ɛ = $(loss.eps)", args...)
 print(io::IO, loss::SmoothedL1HingeLoss, args...) = print(io, typeof(loss).name.name, " with γ = $(loss.gamma)", args...)
 
-@require UnicodePlots begin
-    
-    using UnicodePlots
-    import UnicodePlots: lineplot, lineplot!
+# -----------------------------------------------------------------------------------
+# Plot Recipes
 
-    function show(io::IO, loss::Union{MarginLoss,DistanceLoss,ZeroOneLoss})
-        println(io, loss)
-        newPlot = lineplot(loss, -3:.05:3, margin = 0, width = 20, height = 5, name = " ")
-        xl = xlabel(newPlot)
-        ylabel!(newPlot, "")
-        xlabel!(newPlot, "")
-        annotate!(newPlot, :l, 3, "    ")
-        annotate!(newPlot, :r, 3, "L(y,h(x))", :blue)
-        annotate!(newPlot, :br, "")
-        annotate!(newPlot, :bl, "")
-        print(io, newPlot)
-        newPlot = lineplot(loss', -3:.05:3, margin = 0, width = 20, height = 5, color = :red, name = " ")
-        ylabel!(newPlot, "")
-        xlabel!(newPlot, xl)
-        annotate!(newPlot, :l, 3, "    ")
-        annotate!(newPlot, :r, 3, "L'(y,h(x))", :red)
-        print(io, newPlot)
+_loss_xlabel(loss::Union{MarginLoss, LossFunctions.ZeroOneLoss}) = "y ⋅ h(x)"
+_loss_xlabel(loss::DistanceLoss) = "h(x) - y"
+
+@recipe function plot(loss::ModelLoss, xmin = -2, xmax = 2)
+    :xlabel --> _loss_xlabel(loss)
+    :ylabel --> "L(y, h(x))"
+    :label  --> string(loss)
+    value_fun(loss), xmin, xmax
+end
+
+@recipe function plot{T<:ModelLoss}(losses::AbstractVector{T}, xmin = -2, xmax = 2)
+    :ylabel --> "L(y, h(x))"
+    :label  --> map(string, losses)'
+    if issubplot
+        :n      --> length(losses)
+        :legend --> false
+        :title  --> d[:label]
+        :xlabel --> map(_loss_xlabel, losses)'
+    else
+        :xlabel --> _loss_xlabel(first(losses))
     end
+    map(value_fun, losses), xmin, xmax
+end
 
-    function show(io::IO, loss::LogitProbLoss)
-        println(io, loss)
-        f0(x) = value(loss, 0, x)
-        f1(x) = value(loss, 1, x)
-        newPlot = lineplot([f0, f1], 0.000001, 0.99999, ylim=[0,8], margin = 1, width = 20, height = 5, name = " ")
-        xl = xlabel(newPlot)
-        ylabel!(newPlot, "")
-        xlabel!(newPlot, "")
-        annotate!(newPlot, :r, 2, "y = 0", :blue)
-        annotate!(newPlot, :r, 3, "y = 1", :red)
-        annotate!(newPlot, :l, 3, "L(y,σ) ")
-        annotate!(newPlot, :br, "")
-        annotate!(newPlot, :bl, "")
-        print(io, newPlot)
-        g0(x) = deriv(loss, 0, x)
-        g1(x) = deriv(loss, 1, x)
-        newPlot = lineplot([g0, g1], 0.000001, 0.99999, ylim=[-1,1], margin = 1, width = 20, height = 5, name = " ")
-        xl = xlabel(newPlot)
-        ylabel!(newPlot, "")
-        xlabel!(newPlot, "σ(z)")
-        annotate!(newPlot, :r, 1, "", :blue)
-        annotate!(newPlot, :r, 2, "", :red)
-        annotate!(newPlot, :l, 3, " ∂L/∂z ")
-        print(io, newPlot)
-    end
+# -----------------------------------------------------------------------------------
+# UnicodePlots
 
-    function lineplot(
-            loss::Union{MarginLoss,ZeroOneLoss},
-            args...;
-            name = string(typeof(loss).name.name),
-            nargs...)
-        newPlot = lineplot(value_fun(loss), args...; name = name, nargs...)
-        xlabel!(newPlot, "y * h(x)")
-        ylabel!(newPlot, "L(y,h(x))")
-    end
-
-    function lineplot(
-            loss::DistanceLoss,
-            args...;
-            name = string(typeof(loss).name.name),
-            nargs...)
-        newPlot = lineplot(value_fun(loss), args...; name = name, nargs...)
-        xlabel!(newPlot, "h(x) - y")
-        ylabel!(newPlot, "L(y,h(x))")
-    end
-
-    function lineplot(
-            loss::LogitProbLoss,
-            args...;
-            ylim = [0, 5],
-            title = string(typeof(loss).name.name),
-            nargs...)
-        f0(x) = value(loss, 0, x)
-        f05(x) = value(loss, 0.5, x)
-        f1(x) = value(loss, 1, x)
-        newPlot = lineplot([f0, f05, f1], args...; ylim = ylim, title = title, nargs...)
-        xlabel!(newPlot, "t = σ(wᵀx)")
-        ylabel!(newPlot, "L(y,t)")
-        annotate!(newPlot, :r, 1, "y = 0", :blue)
-        annotate!(newPlot, :r, 2, "y = 0.5", :red)
-        annotate!(newPlot, :r, 3, "y = 1", :yellow)
-    end
-
-    function lineplot(
-            loss::LogitProbLoss;
-            nargs...)
-        lineplot(loss, .000001, .999999; nargs...)
-    end
-
-    function lineplot!{C<:Canvas}(
-            plot::Plot{C},
-            loss::Union{MarginLoss,DistanceLoss,ZeroOneLoss},
-            args...;
-            name = string(typeof(loss).name.name),
-            nargs...)
-        lineplot!(plot, value_fun(loss), args...; name = name, nargs...)
-    end
-
-    function lineplot{T<:ModelLoss}(
-            lossvec::AbstractVector{T}, args...; name = "", nargs...)
-        n = length(lossvec)
-        @assert n > 0
-        newPlot = lineplot(lossvec[1], args...; nargs...)
-        for i = 2:n
-            lineplot!(newPlot, lossvec[i], args...; nargs...)
-        end
-        newPlot
-    end
-
-    function lineplot!{C<:Canvas,T<:ModelLoss}(
-            plot::Plot{C},
-            lossvec::AbstractVector{T},
-            args...; nargs...)
-        n = length(lossvec)
-        @assert n > 0
-        for i = 1:n
-            lineplot!(plot, lossvec[i], args...; nargs...)
-        end
-        plot
-    end
-
-end # require UnicodePlots
-
+# @require UnicodePlots begin
+#
+#     using UnicodePlots
+#     import UnicodePlots: lineplot, lineplot!
+#
+#     function show(io::IO, loss::Union{MarginLoss,DistanceLoss,ZeroOneLoss})
+#         println(io, loss)
+#         newPlot = lineplot(loss, -3:.05:3, margin = 0, width = 20, height = 5, name = " ")
+#         xl = xlabel(newPlot)
+#         ylabel!(newPlot, "")
+#         xlabel!(newPlot, "")
+#         annotate!(newPlot, :l, 3, "    ")
+#         annotate!(newPlot, :r, 3, "L(y,h(x))", :blue)
+#         annotate!(newPlot, :br, "")
+#         annotate!(newPlot, :bl, "")
+#         print(io, newPlot)
+#         newPlot = lineplot(loss', -3:.05:3, margin = 0, width = 20, height = 5, color = :red, name = " ")
+#         ylabel!(newPlot, "")
+#         xlabel!(newPlot, xl)
+#         annotate!(newPlot, :l, 3, "    ")
+#         annotate!(newPlot, :r, 3, "L'(y,h(x))", :red)
+#         print(io, newPlot)
+#     end
+#
+#     function show(io::IO, loss::LogitProbLoss)
+#         println(io, loss)
+#         f0(x) = value(loss, 0, x)
+#         f1(x) = value(loss, 1, x)
+#         newPlot = lineplot([f0, f1], 0.000001, 0.99999, ylim=[0,8], margin = 1, width = 20, height = 5, name = " ")
+#         xl = xlabel(newPlot)
+#         ylabel!(newPlot, "")
+#         xlabel!(newPlot, "")
+#         annotate!(newPlot, :r, 2, "y = 0", :blue)
+#         annotate!(newPlot, :r, 3, "y = 1", :red)
+#         annotate!(newPlot, :l, 3, "L(y,σ) ")
+#         annotate!(newPlot, :br, "")
+#         annotate!(newPlot, :bl, "")
+#         print(io, newPlot)
+#         g0(x) = deriv(loss, 0, x)
+#         g1(x) = deriv(loss, 1, x)
+#         newPlot = lineplot([g0, g1], 0.000001, 0.99999, ylim=[-1,1], margin = 1, width = 20, height = 5, name = " ")
+#         xl = xlabel(newPlot)
+#         ylabel!(newPlot, "")
+#         xlabel!(newPlot, "σ(z)")
+#         annotate!(newPlot, :r, 1, "", :blue)
+#         annotate!(newPlot, :r, 2, "", :red)
+#         annotate!(newPlot, :l, 3, " ∂L/∂z ")
+#         print(io, newPlot)
+#     end
+#
+#     function lineplot(
+#             loss::Union{MarginLoss,ZeroOneLoss},
+#             args...;
+#             name = string(typeof(loss).name.name),
+#             nargs...)
+#         newPlot = lineplot(value_fun(loss), args...; name = name, nargs...)
+#         xlabel!(newPlot, "y * h(x)")
+#         ylabel!(newPlot, "L(y,h(x))")
+#     end
+#
+#     function lineplot(
+#             loss::DistanceLoss,
+#             args...;
+#             name = string(typeof(loss).name.name),
+#             nargs...)
+#         newPlot = lineplot(value_fun(loss), args...; name = name, nargs...)
+#         xlabel!(newPlot, "h(x) - y")
+#         ylabel!(newPlot, "L(y,h(x))")
+#     end
+#
+#     function lineplot(
+#             loss::LogitProbLoss,
+#             args...;
+#             ylim = [0, 5],
+#             title = string(typeof(loss).name.name),
+#             nargs...)
+#         f0(x) = value(loss, 0, x)
+#         f05(x) = value(loss, 0.5, x)
+#         f1(x) = value(loss, 1, x)
+#         newPlot = lineplot([f0, f05, f1], args...; ylim = ylim, title = title, nargs...)
+#         xlabel!(newPlot, "t = σ(wᵀx)")
+#         ylabel!(newPlot, "L(y,t)")
+#         annotate!(newPlot, :r, 1, "y = 0", :blue)
+#         annotate!(newPlot, :r, 2, "y = 0.5", :red)
+#         annotate!(newPlot, :r, 3, "y = 1", :yellow)
+#     end
+#
+#     function lineplot(
+#             loss::LogitProbLoss;
+#             nargs...)
+#         lineplot(loss, .000001, .999999; nargs...)
+#     end
+#
+#     function lineplot!{C<:Canvas}(
+#             plot::Plot{C},
+#             loss::Union{MarginLoss,DistanceLoss,ZeroOneLoss},
+#             args...;
+#             name = string(typeof(loss).name.name),
+#             nargs...)
+#         lineplot!(plot, value_fun(loss), args...; name = name, nargs...)
+#     end
+#
+#     function lineplot{T<:ModelLoss}(
+#             lossvec::AbstractVector{T}, args...; name = "", nargs...)
+#         n = length(lossvec)
+#         @assert n > 0
+#         newPlot = lineplot(lossvec[1], args...; nargs...)
+#         for i = 2:n
+#             lineplot!(newPlot, lossvec[i], args...; nargs...)
+#         end
+#         newPlot
+#     end
+#
+#     function lineplot!{C<:Canvas,T<:ModelLoss}(
+#             plot::Plot{C},
+#             lossvec::AbstractVector{T},
+#             args...; nargs...)
+#         n = length(lossvec)
+#         @assert n > 0
+#         for i = 1:n
+#             lineplot!(plot, lossvec[i], args...; nargs...)
+#         end
+#         plot
+#     end
+#
+# end # require UnicodePlots

--- a/src/loss/io.jl
+++ b/src/loss/io.jl
@@ -37,129 +37,129 @@ end
 # -----------------------------------------------------------------------------------
 # UnicodePlots
 
-# @require UnicodePlots begin
-#
-#     using UnicodePlots
-#     import UnicodePlots: lineplot, lineplot!
-#
-#     function show(io::IO, loss::Union{MarginLoss,DistanceLoss,ZeroOneLoss})
-#         println(io, loss)
-#         newPlot = lineplot(loss, -3:.05:3, margin = 0, width = 20, height = 5, name = " ")
-#         xl = xlabel(newPlot)
-#         ylabel!(newPlot, "")
-#         xlabel!(newPlot, "")
-#         annotate!(newPlot, :l, 3, "    ")
-#         annotate!(newPlot, :r, 3, "L(y,h(x))", :blue)
-#         annotate!(newPlot, :br, "")
-#         annotate!(newPlot, :bl, "")
-#         print(io, newPlot)
-#         newPlot = lineplot(loss', -3:.05:3, margin = 0, width = 20, height = 5, color = :red, name = " ")
-#         ylabel!(newPlot, "")
-#         xlabel!(newPlot, xl)
-#         annotate!(newPlot, :l, 3, "    ")
-#         annotate!(newPlot, :r, 3, "L'(y,h(x))", :red)
-#         print(io, newPlot)
-#     end
-#
-#     function show(io::IO, loss::LogitProbLoss)
-#         println(io, loss)
-#         f0(x) = value(loss, 0, x)
-#         f1(x) = value(loss, 1, x)
-#         newPlot = lineplot([f0, f1], 0.000001, 0.99999, ylim=[0,8], margin = 1, width = 20, height = 5, name = " ")
-#         xl = xlabel(newPlot)
-#         ylabel!(newPlot, "")
-#         xlabel!(newPlot, "")
-#         annotate!(newPlot, :r, 2, "y = 0", :blue)
-#         annotate!(newPlot, :r, 3, "y = 1", :red)
-#         annotate!(newPlot, :l, 3, "L(y,σ) ")
-#         annotate!(newPlot, :br, "")
-#         annotate!(newPlot, :bl, "")
-#         print(io, newPlot)
-#         g0(x) = deriv(loss, 0, x)
-#         g1(x) = deriv(loss, 1, x)
-#         newPlot = lineplot([g0, g1], 0.000001, 0.99999, ylim=[-1,1], margin = 1, width = 20, height = 5, name = " ")
-#         xl = xlabel(newPlot)
-#         ylabel!(newPlot, "")
-#         xlabel!(newPlot, "σ(z)")
-#         annotate!(newPlot, :r, 1, "", :blue)
-#         annotate!(newPlot, :r, 2, "", :red)
-#         annotate!(newPlot, :l, 3, " ∂L/∂z ")
-#         print(io, newPlot)
-#     end
-#
-#     function lineplot(
-#             loss::Union{MarginLoss,ZeroOneLoss},
-#             args...;
-#             name = string(typeof(loss).name.name),
-#             nargs...)
-#         newPlot = lineplot(value_fun(loss), args...; name = name, nargs...)
-#         xlabel!(newPlot, "y * h(x)")
-#         ylabel!(newPlot, "L(y,h(x))")
-#     end
-#
-#     function lineplot(
-#             loss::DistanceLoss,
-#             args...;
-#             name = string(typeof(loss).name.name),
-#             nargs...)
-#         newPlot = lineplot(value_fun(loss), args...; name = name, nargs...)
-#         xlabel!(newPlot, "h(x) - y")
-#         ylabel!(newPlot, "L(y,h(x))")
-#     end
-#
-#     function lineplot(
-#             loss::LogitProbLoss,
-#             args...;
-#             ylim = [0, 5],
-#             title = string(typeof(loss).name.name),
-#             nargs...)
-#         f0(x) = value(loss, 0, x)
-#         f05(x) = value(loss, 0.5, x)
-#         f1(x) = value(loss, 1, x)
-#         newPlot = lineplot([f0, f05, f1], args...; ylim = ylim, title = title, nargs...)
-#         xlabel!(newPlot, "t = σ(wᵀx)")
-#         ylabel!(newPlot, "L(y,t)")
-#         annotate!(newPlot, :r, 1, "y = 0", :blue)
-#         annotate!(newPlot, :r, 2, "y = 0.5", :red)
-#         annotate!(newPlot, :r, 3, "y = 1", :yellow)
-#     end
-#
-#     function lineplot(
-#             loss::LogitProbLoss;
-#             nargs...)
-#         lineplot(loss, .000001, .999999; nargs...)
-#     end
-#
-#     function lineplot!{C<:Canvas}(
-#             plot::Plot{C},
-#             loss::Union{MarginLoss,DistanceLoss,ZeroOneLoss},
-#             args...;
-#             name = string(typeof(loss).name.name),
-#             nargs...)
-#         lineplot!(plot, value_fun(loss), args...; name = name, nargs...)
-#     end
-#
-#     function lineplot{T<:ModelLoss}(
-#             lossvec::AbstractVector{T}, args...; name = "", nargs...)
-#         n = length(lossvec)
-#         @assert n > 0
-#         newPlot = lineplot(lossvec[1], args...; nargs...)
-#         for i = 2:n
-#             lineplot!(newPlot, lossvec[i], args...; nargs...)
-#         end
-#         newPlot
-#     end
-#
-#     function lineplot!{C<:Canvas,T<:ModelLoss}(
-#             plot::Plot{C},
-#             lossvec::AbstractVector{T},
-#             args...; nargs...)
-#         n = length(lossvec)
-#         @assert n > 0
-#         for i = 1:n
-#             lineplot!(plot, lossvec[i], args...; nargs...)
-#         end
-#         plot
-#     end
-#
-# end # require UnicodePlots
+@require UnicodePlots begin
+
+    using UnicodePlots
+    import UnicodePlots: lineplot, lineplot!
+
+    function show(io::IO, loss::Union{MarginLoss,DistanceLoss,ZeroOneLoss})
+        println(io, loss)
+        newPlot = lineplot(loss, -3:.05:3, margin = 0, width = 20, height = 5, name = " ")
+        xl = xlabel(newPlot)
+        ylabel!(newPlot, "")
+        xlabel!(newPlot, "")
+        annotate!(newPlot, :l, 3, "    ")
+        annotate!(newPlot, :r, 3, "L(y,h(x))", :blue)
+        annotate!(newPlot, :br, "")
+        annotate!(newPlot, :bl, "")
+        print(io, newPlot)
+        newPlot = lineplot(loss', -3:.05:3, margin = 0, width = 20, height = 5, color = :red, name = " ")
+        ylabel!(newPlot, "")
+        xlabel!(newPlot, xl)
+        annotate!(newPlot, :l, 3, "    ")
+        annotate!(newPlot, :r, 3, "L'(y,h(x))", :red)
+        print(io, newPlot)
+    end
+
+    function show(io::IO, loss::LogitProbLoss)
+        println(io, loss)
+        f0(x) = value(loss, 0, x)
+        f1(x) = value(loss, 1, x)
+        newPlot = lineplot([f0, f1], 0.000001, 0.99999, ylim=[0,8], margin = 1, width = 20, height = 5, name = " ")
+        xl = xlabel(newPlot)
+        ylabel!(newPlot, "")
+        xlabel!(newPlot, "")
+        annotate!(newPlot, :r, 2, "y = 0", :blue)
+        annotate!(newPlot, :r, 3, "y = 1", :red)
+        annotate!(newPlot, :l, 3, "L(y,σ) ")
+        annotate!(newPlot, :br, "")
+        annotate!(newPlot, :bl, "")
+        print(io, newPlot)
+        g0(x) = deriv(loss, 0, x)
+        g1(x) = deriv(loss, 1, x)
+        newPlot = lineplot([g0, g1], 0.000001, 0.99999, ylim=[-1,1], margin = 1, width = 20, height = 5, name = " ")
+        xl = xlabel(newPlot)
+        ylabel!(newPlot, "")
+        xlabel!(newPlot, "σ(z)")
+        annotate!(newPlot, :r, 1, "", :blue)
+        annotate!(newPlot, :r, 2, "", :red)
+        annotate!(newPlot, :l, 3, " ∂L/∂z ")
+        print(io, newPlot)
+    end
+
+    function lineplot(
+            loss::Union{MarginLoss,ZeroOneLoss},
+            args...;
+            name = string(typeof(loss).name.name),
+            nargs...)
+        newPlot = lineplot(value_fun(loss), args...; name = name, nargs...)
+        xlabel!(newPlot, "y * h(x)")
+        ylabel!(newPlot, "L(y,h(x))")
+    end
+
+    function lineplot(
+            loss::DistanceLoss,
+            args...;
+            name = string(typeof(loss).name.name),
+            nargs...)
+        newPlot = lineplot(value_fun(loss), args...; name = name, nargs...)
+        xlabel!(newPlot, "h(x) - y")
+        ylabel!(newPlot, "L(y,h(x))")
+    end
+
+    function lineplot(
+            loss::LogitProbLoss,
+            args...;
+            ylim = [0, 5],
+            title = string(typeof(loss).name.name),
+            nargs...)
+        f0(x) = value(loss, 0, x)
+        f05(x) = value(loss, 0.5, x)
+        f1(x) = value(loss, 1, x)
+        newPlot = lineplot([f0, f05, f1], args...; ylim = ylim, title = title, nargs...)
+        xlabel!(newPlot, "t = σ(wᵀx)")
+        ylabel!(newPlot, "L(y,t)")
+        annotate!(newPlot, :r, 1, "y = 0", :blue)
+        annotate!(newPlot, :r, 2, "y = 0.5", :red)
+        annotate!(newPlot, :r, 3, "y = 1", :yellow)
+    end
+
+    function lineplot(
+            loss::LogitProbLoss;
+            nargs...)
+        lineplot(loss, .000001, .999999; nargs...)
+    end
+
+    function lineplot!{C<:Canvas}(
+            plot::Plot{C},
+            loss::Union{MarginLoss,DistanceLoss,ZeroOneLoss},
+            args...;
+            name = string(typeof(loss).name.name),
+            nargs...)
+        lineplot!(plot, value_fun(loss), args...; name = name, nargs...)
+    end
+
+    function lineplot{T<:ModelLoss}(
+            lossvec::AbstractVector{T}, args...; name = "", nargs...)
+        n = length(lossvec)
+        @assert n > 0
+        newPlot = lineplot(lossvec[1], args...; nargs...)
+        for i = 2:n
+            lineplot!(newPlot, lossvec[i], args...; nargs...)
+        end
+        newPlot
+    end
+
+    function lineplot!{C<:Canvas,T<:ModelLoss}(
+            plot::Plot{C},
+            lossvec::AbstractVector{T},
+            args...; nargs...)
+        n = length(lossvec)
+        @assert n > 0
+        for i = 1:n
+            lineplot!(plot, lossvec[i], args...; nargs...)
+        end
+        plot
+    end
+
+end # require UnicodePlots

--- a/src/risk/prediction.jl
+++ b/src/risk/prediction.jl
@@ -94,7 +94,7 @@ end
     k = length(w) - 1
     n = size(X, 2)
     @_dimcheck size(X, 1) == k && size(buffer) == (1, n)
-    w⃗ = view(w, 1:k)
+    w⃗ = sub(w, 1:k)
     @inbounds b = h.bias * w[k+1]
     At_mul_B!(buffer, w⃗, X)
     broadcast!(+, buffer, buffer, b)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,5 +1,6 @@
 julia 0.4
 BaseTestNext
+RecipesBase
 UnicodePlots
 MLDataUtils
 DualNumbers


### PR DESCRIPTION
In a nutshell... I found one instance of `view` and replaced it with `sub` to remove the dependency on ArrayViews.  I commented out the UnicodePlots sections (which seem to match functionality of the recipes... correct me if I'm wrong there), and copied the recipes from MLPlots.  This let me remove the dependency on Requires as well.

There are some tests which plot directly into UnicodePlots... I left those.  Eventually maybe change to show them through Plots with the unicodeplots backend?

@Evizero  I think this is ok to merge, but please take a look.

Question: Is it reasonable to try to remove the dependency on MLBase?  I don't remember which parts depend on that, and I seem to remember that it wasn't very actively supported.